### PR TITLE
#156662429 Fix the telegram notification bug

### DIFF
--- a/.circleci/deploy.sh
+++ b/.circleci/deploy.sh
@@ -12,11 +12,7 @@ download_terraform() {
 
 prepare_deployment_script() {
     cd ~
-    if [ "$CIRCLE_USERNAME" == "JamesKirkAndSpock" ]; then
-        git clone -b continuous-deployment-156068297 https://github.com/JamesKirkAndSpock/Hirola-Deployment-Script.git
-    else
-        git clone -b non-telegram-continuous-deployment-156068297 https://github.com/JamesKirkAndSpock/Hirola-Deployment-Script.git
-    fi
+    git clone -b continuous-deployment-156068297 https://github.com/JamesKirkAndSpock/Hirola-Deployment-Script.git
     cd ~/Hirola-Deployment-Script
     mkdir account-folder
     cd account-folder


### PR DESCRIPTION
#### What does this PR do?

This P.R fixes a bug identified  while sending notification messages on telegram. The bug was that the notification was been delivered with three messages in stead of one. The time was also inconvenient.

#### Description of Task to be completed?

The task involves ensuring that the telegram message is sent once and not thrice. This meant ensuring that the cron-job was being added to only one instance and not the three of them. 

It was also decided that the cron-job time needed to be changed to 4 hours earlier than the time it was scheduled to run.

#### How should this be manually tested?

SSH to the devops-hirola instance and ensure that on the root directory the files telegram.sh and review.sh exist. SSH to all the other instances apart from the former and ensure that the two files do not exist. 

Run the command `crontab -l` to list the cronjobs that exist. Two cronjobs should exist. One cronjob should send messages five days a week at 1400 UTC time and the other on Fridays only.

View the console on the devops-hirola instance and ensure that on the console the statement 'Copying notification scripts' and 'Cron job added to run the scripts' are both echoed. The statement 'Cron jobs not added. Notification scripts not copied.' should be echoed on any other instances.

Watch the relevant telegram group and determine that messages are being sent every weekday and on Fridays an extra message is being sent.

#### What are the relevant pivotal tracker stories?

#156662429




