### PR TITLE
bug(email): fix change_email wording

### DIFF
--- a/hirola/front/templates/front/change_email.html
+++ b/hirola/front/templates/front/change_email.html
@@ -6,7 +6,7 @@
         <div class="col m2"></div>
         <div class="col m8">
             <div class="col s12 form-content">
-                <h5>Please provide new email for {{ user.email }}</h5>
+                <h5>Please provide new email for {{ current_user_email }}</h5>
                 <form method="post">
                   {% csrf_token %}
                     <div class="row">

--- a/hirola/front/tests/user_email/test_view.py
+++ b/hirola/front/tests/user_email/test_view.py
@@ -155,6 +155,8 @@ class ChangeEmailView(BaseTestCase):
         response = self.sivanna.post("/change_email", {"email": "tripona@gmail.com"})
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "The email address you entered has already been registered.")
+        message = "Please provide new email for sivanna@gmail.com"
+        self.assertContains(response, message)
 
     def test_similar_email(self):
         '''
@@ -172,6 +174,8 @@ class ChangeEmailView(BaseTestCase):
         self.assertEqual(response.status_code, 200)
         error_message = ChangeEmailForm.error_messages['invalid_email']
         self.assertContains(response, error_message)
+        message = "Please provide new email for sivanna@gmail.com"
+        self.assertContains(response, message)
 
     def test_valid_data(self):
         '''
@@ -195,6 +199,3 @@ class ChangeEmailView(BaseTestCase):
         self.assertEqual(edited_user.change_email, "pinotico@gmail.com")
         self.assertIsNotNone(edited_user.change_email_tracker)
         self.assertContains(response, "We have sent you a link to your new email to activate it")
-
-
-

--- a/hirola/front/views.py
+++ b/hirola/front/views.py
@@ -347,7 +347,9 @@ def change_email_view(request):
             user.save()
             form.send_email(request, user)
             return render(request, 'front/change_email_sent.html')
-        args = {"form": form, 'social_media': social_media, 'categories': phone_categories}
+        args = {'form': form, 'social_media': social_media,
+                'categories': phone_categories,
+                'current_user_email': user.email}
         return render(request, 'front/change_email.html', args)
     args = {"form": ChangeEmailForm(), 'social_media': social_media,
             'categories': phone_categories}


### PR DESCRIPTION
- fix the wording on change_email
- ensure the email rendered is accurate

[ Fixes #163943232]

#### Short description of what this resolves:
A bug on the change_email page where the email page would render an email of a user who is registered already on the site in case this was the email that was to be changed into.
#### Changes proposed in this pull request:

- Stop using the request.user object to render the email
- Apparently for some reason this object will render a registered email in case it is added to the form
- Render the email from the User.objects.get() returned object.
#### Screenshots:
N/A 
**Fixes**:  https://www.pivotaltracker.com/story/show/163843232

