### PR TITLE
#163079447 Configure email sending FAQ

### DIFF
--- a/hirola/front/forms/user_forms.py
+++ b/hirola/front/forms/user_forms.py
@@ -531,9 +531,12 @@ class ContactUsForm(forms.Form):
     def send_email(self):
         """Send email to site administrators."""
         to_email = settings.EMAIL_HOST_USER
-        from_email = self.cleaned_data.get('email')
+        from_email = settings.DEFAULT_FROM_EMAIL
         sender_name = self.cleaned_data.get('name') or 'Anonymous User'
-        subject = "Help and support request" + " from " + sender_name
+        email = self.cleaned_data.get('email')
+        subject = "Help and support request from {} of email {}".format(
+            sender_name, email
+        )
         body = self.cleaned_data.get('comment')
         body += '\n'
         body += from_email

--- a/hirola/front/tests/user_email/test_email.py
+++ b/hirola/front/tests/user_email/test_email.py
@@ -319,10 +319,11 @@ class FAQSupportEmailTestCase(BaseTestCase):
         form.send_email()
         self.assertEqual(len(mail.outbox), 1)
         self.assertEqual(mail.outbox[0].to, [settings.EMAIL_HOST_USER])
-        subject = "Help and support request from peter"
+        subject = "Help and support request from peter of email p@g.com"
         self.assertEqual(mail.outbox[0].subject, subject)
         body = "I have nothing to say"
         body += '\n'
-        body += request.POST.get('email')
+        body += settings.DEFAULT_FROM_EMAIL
         self.assertEqual(mail.outbox[0].body, body)
-        self.assertEqual(mail.outbox[0].from_email, "p@g.com")
+        self.assertEqual(
+            mail.outbox[0].from_email, settings.DEFAULT_FROM_EMAIL)

--- a/hirola/hirola/settings/staging.py
+++ b/hirola/hirola/settings/staging.py
@@ -4,7 +4,7 @@ production stage.
 """
 from .base import *
 
-# DEBUG = False
+DEBUG = False
 GS_BUCKET_NAME = os.environ.get('GS_BUCKET_NAME')
 MEDIA_URL = os.environ.get('GS_BUCKET_URL')
 DEFAULT_FILE_STORAGE = 'storages.backends.gcloud.GoogleCloudStorage'

--- a/hirola/hirola/settings/staging.py
+++ b/hirola/hirola/settings/staging.py
@@ -4,7 +4,7 @@ production stage.
 """
 from .base import *
 
-DEBUG = False
+# DEBUG = False
 GS_BUCKET_NAME = os.environ.get('GS_BUCKET_NAME')
 MEDIA_URL = os.environ.get('GS_BUCKET_URL')
 DEFAULT_FILE_STORAGE = 'storages.backends.gcloud.GoogleCloudStorage'


### PR DESCRIPTION
#### Short description of what this resolves:
Allows email sending on the FAQ

#### Changes proposed in this pull request:

- An error was occurring when the send_email method was executing the operation of sending an email. The error was in the value that was being provided to the `from` argument in the method. This could not be the email that the user wanted to be reached at with, but rather it had to the email of the account that we are using, sending to itself.

#### Screenshots:
n/a

**Fixes**: #163079447 

