### PR TITLE
feature(authenticated user buy now): enable the buy now feature for a…

### DIFF
--- a/hirola/front/tests/cart/test_views.py
+++ b/hirola/front/tests/cart/test_views.py
@@ -330,3 +330,29 @@ class CartViewsTestCase(BaseTestCase):
         cart = Cart.objects.get(
             phone_model_item=self.samsung_note_5_rose_gold)
         self.assertTrue(cart)
+
+    def test_buy_now_logged_in(self):
+        """
+        Test that when a user request to buy now while logged in
+            - That their item is saved to the cart
+            - and they are redirected to the checkout page
+        """
+        self.winniethepooh = Client()
+        User.objects.create(email="winnie@thepooh.com")
+        user = User.objects.get(email="winnie@thepooh.com")
+        self.winniethepooh.force_login(user)
+        form = {
+            'buy_now': '1',
+            'quantity': '1',
+            'phone_model_input': '{}'.format(
+                self.samsung_note_5_rose_gold.phone_model.id),
+            'phone_model_item': '{}'.format(
+                self.samsung_note_5_rose_gold.id)
+        }
+        response = self.winniethepooh.post('/profile/{}/'.format(
+            self.samsung_note_5_rose_gold.pk), form, follow=True)
+        self.assertRedirects(response, "/checkout")
+        self.assertContains(response, '1. Delivery Options')
+        cart = Cart.objects.get(
+            phone_model_item=self.samsung_note_5_rose_gold)
+        self.assertTrue(cart)

--- a/hirola/front/tests/hot_deals/test_views.py
+++ b/hirola/front/tests/hot_deals/test_views.py
@@ -69,3 +69,29 @@ class HotDealsViewsTestCase(BaseTestCase):
              'quantity': 2, 'owner': '',
              'buy_now': '1'}, follow=True)
         self.assertRedirects(response, "/login?next=/checkout")
+
+    def test_buy_hotdeal_now_logged_in(self):
+        """
+        Test that when a user clicks on the buy now button on the hotdeals page
+            - That their item is saved to the cart
+            - and they are redirected to the checkout page
+        """
+        self.winniethepooh = Client()
+        User.objects.create(email="winnie@thepooh.com")
+        user = User.objects.get(email="winnie@thepooh.com")
+        self.winniethepooh.force_login(user)
+        form = {
+            'buy_now': '1',
+            'quantity': '1',
+            'phone_model_input': '{}'.format(
+                self.samsung_note_7_rose_gold.phone_model.id),
+            'phone_model_item': '{}'.format(
+                self.samsung_note_7_rose_gold.id)
+        }
+        response = self.winniethepooh.post('/profile/{}/'.format(
+            self.samsung_note_7_rose_gold.pk), form, follow=True)
+        self.assertRedirects(response, "/checkout")
+        self.assertContains(response, '1. Delivery Options')
+        cart = Cart.objects.get(
+            phone_model_item=self.samsung_note_7_rose_gold)
+        self.assertTrue(cart)

--- a/hirola/front/views.py
+++ b/hirola/front/views.py
@@ -905,6 +905,11 @@ def buy_now(request):
     """
     Go to checkout as anonymous user
     """
+    if not request.user.is_anonymous:
+        form = check_cart_exists(request)
+        if form.is_valid():
+            form.save()
+            return redirect('/checkout')
     form = check_cart_exists_anonymous(request)
     if form.is_valid():
         cart = form.save(commit=False)


### PR DESCRIPTION
#### Short description of what this resolves:
Check if user is authenticated and enable them to buy an item or a hotdeal with the buy now button

#### Changes proposed in this pull request:
- enable logged in user to **buy now** hotdeal
- enable logged in user to **buy now** any other item

**Fixes**: [#165460880](https://www.pivotaltracker.com/story/show/165460880)

