### PR TITLE
feature(order email notification): send email to user after placing o…

### DIFF
--- a/hirola/dev-requirements.txt
+++ b/hirola/dev-requirements.txt
@@ -5,6 +5,7 @@ chardet==3.0.4
 coverage==4.5.2
 coveralls==1.5.1
 Django==2.0.2
+django-inlinecss==0.2.0
 django-storages==1.6.6
 docopt==0.6.2
 google-api-core==1.2.0

--- a/hirola/front/forms/cart_forms.py
+++ b/hirola/front/forms/cart_forms.py
@@ -113,30 +113,28 @@ class ShippingAddressForm(forms.ModelForm):
         return address
 
 
-def send_order_notice_email(request, user, cart, cart_total, shipping_address):
+def send_order_notice_email(request, cart, cart_total, shipping_address):
     """
     Send an email to the user notifying them that their order is in
     processing.
     """
     current_site = get_current_site(request)
     context = {
-        'user': user,
+        'user': request.user,
         'domain': current_site.domain,
-        'uid': urlsafe_base64_encode(force_bytes(user.pk)).decode(),
-        'token': account_activation_token.make_token(user),
+        'uid': urlsafe_base64_encode(force_bytes(request.user.pk)).decode(),
+        'token': account_activation_token.make_token(request.user),
         'protocol': 'https' if request.is_secure() else 'http',
         'cart': cart,
         'cart_total': cart_total,
         'shipping_address': shipping_address
     }
-    to_email = user.email
+    to_email = request.user.email
     subject = loader.render_to_string(
-        "front/confirmation_email_subject.txt", context
-        )
+        "front/confirmation_email_subject.txt", context)
     subject = ''.join(subject.splitlines())
     body = loader.render_to_string(
-        "front/confirmation_email_body.html", context
-        )
+        "front/confirmation_email_body.html", context)
     email_message = EmailMultiAlternatives(subject, body, None, [to_email])
     email_message.content_subtype = "html"
     email_message.send()

--- a/hirola/front/static/front/css/confirmation_email_body.css
+++ b/hirola/front/static/front/css/confirmation_email_body.css
@@ -1,0 +1,53 @@
+h2 {
+    color: #3cba54;
+}
+
+.main {
+    font-size: 120%;
+}
+
+.row {
+    font-size: 120%;
+}
+
+.title {
+    display: flex;
+    border-bottom: solid 0.05em;
+    border-bottom-color: #E8E8E8;
+}
+
+.col-a {
+    flex-basis: 50%;
+    margin-right: 300px;
+}
+
+.col-b {
+    flex-basis: 50%;
+    flex-basis: 300px;
+}
+
+.text-title {
+    font-weight: 600;
+}
+
+.a {
+    text-decoration: none;
+    color: #3cba54;
+}
+
+li {
+    list-style: decimal;
+}
+
+.foot{
+    font-size: 90%;
+    color: gray;
+    margin-top: 10px;
+    border-top: solid 0.05em;
+    border-top-color: #E8E8E8;
+}
+
+
+#total {
+    margin-left: 20px;
+}

--- a/hirola/front/templates/front/confirmation_email_body.html
+++ b/hirola/front/templates/front/confirmation_email_body.html
@@ -1,0 +1,86 @@
+{% load inlinecss %}
+{% inlinecss "front/css/confirmation_email_body.css" %}
+{% load static %}
+<!DOCTYPE html>
+<html lang="en">
+<body>
+        <div class="row">
+                <div class="title">
+                        <div class="col-a">
+                            <h2>teke</h2>
+                        </div>
+                        <div class="col-b">
+                                <h2>Order Confirmation</h2>
+                        </div>
+                </div>
+                <div class="content">
+                        <p>
+                            Thanks for shopping at teke {{ user.first_name }}.
+                        </p>
+                        <p>
+                            We will update you when the item ships.
+                        </p>
+                </div>
+        </div>
+        <div class="row">
+                <div class="title">
+                        <div class="col-a">
+                                <h2>Order Details</h2>
+                        </div>
+                </div>
+                <div class="content">
+                        {% for obj in cart %}
+                        <li><span class="text-title">{{obj.phone_model_item}}</span> Ksh. {{obj.phone_model_item.price}}</li>
+                        {% endfor %}
+                        <p>
+                            <span class="text-title" id="total">Order Total: Ksh. </span>{{cart_total}}
+                        </p>
+                </div>
+        </div>
+        <div class="row">
+                <div class="title">
+                        <div class="col-a">
+                            <h2>Shipping Details</h2>
+                        </div>
+                </div>
+                <div class="content">
+                        <p>
+                            These items will ship in 2-3 weeks. We will update you on the delivery
+                            progress as the items are shipped.
+                        </p>
+                        {% if shipping_address != None %}
+                        <p>
+                            <span class="text-title">Phone Number:</span> {{shipping_address.phone_number}}
+                        </p>
+                        <p>
+                            <span class="text-title">Town:</span> {{shipping_address}}
+                        </p>
+                        {% else %}
+                        <p>
+                            <span class="text-title">Phone Number:</span> {{user.phone_number}}
+                        </p>
+                        {% endif %}
+                </div>
+        </div>
+        <div class="row">
+                <div class="content">
+                        <p>
+                           Have a question? please visit <span><a href="{{ protocol }}://{{ domain }}{% url 'front:help' %}">teke help center</a></span>
+                        </p>
+                        <p>
+                           We hope to see you soon again.
+                        </p>
+                        <p>
+                            <span><a href="peter.tekesquared.com">teketeke.com</a></span>
+                        </p>
+                </div>
+        </div>
+        <div class="foot">
+                <p>
+                    By placing your order, you agree to pay the whole amount of the products ordered,
+                    as well as to teke's <span><a href="{{ protocol }}://{{ domain }}{% url 'front:privacy' %}">privacy policy</a></span>
+                </p>
+        </div>
+</body>
+</html>
+{% endinlinecss %}

--- a/hirola/front/templates/front/confirmation_email_subject.txt
+++ b/hirola/front/templates/front/confirmation_email_subject.txt
@@ -1,0 +1,1 @@
+Order Confirmation

--- a/hirola/front/templates/front/dashboard.html
+++ b/hirola/front/templates/front/dashboard.html
@@ -286,7 +286,7 @@
                                 <b>Item</b>
                             </p>
                             <div class="img">
-                                <img src="{{ MEDIA_URL }}{{ order.phone.main_image }}" height="200" width="200">
+                                <img src="{{ MEDIA_URL }}{{ order.phone.main_image }}" width="80" height="150">
                             </div>
                         </div>
                     </div>

--- a/hirola/front/tests/cart/test_email.py
+++ b/hirola/front/tests/cart/test_email.py
@@ -1,0 +1,59 @@
+from front.base_test import BaseTestCase, User, Cart
+from front.models import ShippingAddress
+from front.forms.cart_forms import send_order_notice_email
+from django.test import RequestFactory
+from django.core import mail
+from front.views import get_cart_total
+from django.conf import settings
+from django.template.loader import render_to_string
+
+
+class NoticeEmailTestCase(BaseTestCase):
+    """
+    Test sending email after user places order.
+    """
+
+    def setUp(self):
+        """Setup email tests preconditions."""
+        super(NoticeEmailTestCase, self).setUp()
+
+    def test_order_notice_email_sent(self):
+        """
+        Test user
+        """
+        request = RequestFactory()
+        request = request.post(
+            "", {'email': 'naisomia@gmail.com', 'password': 'secret'}
+            )
+        User.objects.create_user(email="sivanna@gmail.com", password="secret")
+        user = User.objects.get(email="sivanna@gmail.com")
+        request.user = user
+        Cart.objects.create(
+            phone_model_item=self.samsung_note_5_rose_gold,
+            quantity=2, owner=user)
+        cart = Cart.objects.filter(owner=request.user)
+        shipping_address = ShippingAddress.objects.create(
+            pickup=False,
+            location='Kibera',
+            phone_number=712893454
+        )
+        send_order_notice_email(
+            request, user, cart, get_cart_total(cart), shipping_address)
+        self.assertEqual(len(mail.outbox), 1)
+        self.assertEqual(mail.outbox[0].to, ['sivanna@gmail.com'])
+        subject = "Order Confirmation"
+        self.assertEqual(mail.outbox[0].subject, subject)
+        body_content = "Thanks for shopping at teke"
+        rendered = str(mail.outbox[0].body)
+        self.assertIn(body_content, rendered)
+        item_detail = "<li style=\"list-style: decimal\">".format(
+            "<span class=\"text-title\" style=\"font-weight: 600\">"
+            "Samsung Note 5</span> Ksh. 25000</li>")
+        self.assertIn(item_detail, rendered)
+        shipping = "<span class=\"text-title\" style=\"font-weight: 600\">"\
+                   "Town:</span> Kibera"
+        self.assertIn(shipping, rendered)
+        item_title = "<span class=\"text-title\" id=\"total\" "\
+                     "style=\"font-weight: 600; margin-left: 20px\">"\
+                     "Order Total: Ksh. </span>50000"
+        self.assertIn(item_title, rendered)

--- a/hirola/front/tests/cart/test_email.py
+++ b/hirola/front/tests/cart/test_email.py
@@ -4,8 +4,6 @@ from front.forms.cart_forms import send_order_notice_email
 from django.test import RequestFactory
 from django.core import mail
 from front.views import get_cart_total
-from django.conf import settings
-from django.template.loader import render_to_string
 
 
 class NoticeEmailTestCase(BaseTestCase):
@@ -23,8 +21,7 @@ class NoticeEmailTestCase(BaseTestCase):
         """
         request = RequestFactory()
         request = request.post(
-            "", {'email': 'naisomia@gmail.com', 'password': 'secret'}
-            )
+            "", {'email': 'naisomia@gmail.com', 'password': 'secret'})
         User.objects.create_user(email="sivanna@gmail.com", password="secret")
         user = User.objects.get(email="sivanna@gmail.com")
         request.user = user
@@ -38,7 +35,7 @@ class NoticeEmailTestCase(BaseTestCase):
             phone_number=712893454
         )
         send_order_notice_email(
-            request, user, cart, get_cart_total(cart), shipping_address)
+            request, cart, get_cart_total(cart), shipping_address)
         self.assertEqual(len(mail.outbox), 1)
         self.assertEqual(mail.outbox[0].to, ['sivanna@gmail.com'])
         subject = "Order Confirmation"

--- a/hirola/front/tests/test_views.py
+++ b/hirola/front/tests/test_views.py
@@ -307,7 +307,7 @@ class ContactUsTestcase(BaseTestCase):
 
 
 class FAQSupportEmailTestCase(BaseTestCase):
-    """Tests Contact us page views"""
+    """Tests FAQs page views"""
 
     def setUp(self):
         """Set the initial state of the tests."""
@@ -344,7 +344,7 @@ class FAQSupportEmailTestCase(BaseTestCase):
 
 
 class ShippingAddressTestCase(BaseTestCase):
-    """Tests Contact us page views"""
+    """Tests shipping address can be collected and stored"""
 
     def setUp(self):
         """Set the initial state of the tests."""

--- a/hirola/front/views.py
+++ b/hirola/front/views.py
@@ -923,7 +923,7 @@ def populate_order(request, address):
             total_price=obj.total_price, shipping_address=address)
         Cart.objects.filter(id=obj.id).delete()
     send_order_notice_email(
-        request, request.user, cart, get_cart_total(cart), address)
+        request, cart, get_cart_total(cart), address)
     return redirect('/dashboard#orders')
 
 

--- a/hirola/front/views.py
+++ b/hirola/front/views.py
@@ -31,7 +31,7 @@ from front.forms.user_forms import (
     resend_activation_email, ContactUsForm,
     )
 from front.forms.cart_forms import (
-    CartForm, CartOwnerForm, ShippingAddressForm)
+    CartForm, CartOwnerForm, ShippingAddressForm, send_order_notice_email)
 
 
 def page_view(request):
@@ -922,6 +922,8 @@ def populate_order(request, address):
             phone=obj.phone_model_item, status=order_status,
             total_price=obj.total_price, shipping_address=address)
         Cart.objects.filter(id=obj.id).delete()
+    send_order_notice_email(
+        request, request.user, cart, get_cart_total(cart), address)
     return redirect('/dashboard#orders')
 
 

--- a/hirola/hirola/settings/base.py
+++ b/hirola/hirola/settings/base.py
@@ -39,6 +39,7 @@ INSTALLED_APPS = [
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'django.contrib.humanize',
+    'django_inlinecss'
 ]
 
 MIDDLEWARE = [
@@ -137,6 +138,8 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/1.11/howto/static-files/
 
 STATIC_URL = '/static/'
+STATIC_DIR = BASE_DIR[:-6]
+STATIC_ROOT = os.path.join(STATIC_DIR, 'front/static')
 
 AUTH_USER_MODEL = 'front.User'
 

--- a/hirola/requirements.txt
+++ b/hirola/requirements.txt
@@ -1,9 +1,15 @@
 astroid==1.6.5
+autopep8==1.4.3
+beautifulsoup4==4.7.1
 cachetools==2.1.0
 certifi==2018.4.16
 chardet==3.0.4
+cssselect==1.0.3
+cssutils==1.0.2
 Django==2.0.2
+django-inlinecss==0.2.0
 django-storages==1.6.6
+future==0.17.1
 google-api-core==1.2.0
 google-auth==1.5.0
 google-cloud-core==0.28.1
@@ -14,9 +20,11 @@ gunicorn==19.9.0
 idna==2.6
 isort==4.3.4
 lazy-object-proxy==1.3.1
+lxml==4.3.4
 mccabe==0.6.1
 pep8==1.7.1
 Pillow==5.2.0
+premailer==3.0.0
 protobuf==3.5.2.post1
 psycopg2==2.7.4
 psycopg2-binary==2.7.4
@@ -25,6 +33,7 @@ pyasn1-modules==0.2.1
 pycodestyle==2.4.0
 PyJWT==1.6.4
 pylint==1.9.2
+pynliner==0.8.0
 PySocks==1.6.8
 python-memcached==1.59
 pytz==2018.4
@@ -32,6 +41,7 @@ requests==2.18.4
 rsa==3.4.2
 selenium==3.141.0
 six==1.11.0
+soupsieve==1.9.1
 twilio==6.16.4
 urllib3==1.22
 wrapt==1.10.11


### PR DESCRIPTION
#### Short description of what this resolves:
Send email to user to notify them that their order has been registered and processing has begun

#### Changes proposed in this pull request:

- send email to user
- add django_inlinecss dependency to ease styling of email
-
#### Screenshots:

**Fixes**: [#166687211](https://www.pivotaltracker.com/story/show/166687211)

