### PR TITLE
chore(confirm email button icons): replace current icons on the confi…

### DIFF
--- a/hirola/front/static/front/css/signup_email.css
+++ b/hirola/front/static/front/css/signup_email.css
@@ -1,0 +1,19 @@
+.google-color {
+    background: #db4a39;
+}
+
+.fa-google{
+    color: white;
+}
+
+.yahoo {
+    background:  #430297;
+}
+
+.outlook {
+    background: #0072C6;
+}
+
+.icloud {
+    background: #5cc1fc;
+}

--- a/hirola/front/templates/registration/signup_email_sent.html
+++ b/hirola/front/templates/registration/signup_email_sent.html
@@ -2,6 +2,7 @@
 {% block styles %}
 {{ block.super }} {% load static %}
 <link rel="stylesheet" type="text/css" href="{% static 'front/css/style.css' %}" />
+<link rel="stylesheet" type="text/css" href="{% static 'front/css/signup_email.css' %}" />
 <link rel="stylesheet" type="text/css" href="{% static 'front/css/base_grid.css' %}" />
 {% endblock %}
 {% block content %}
@@ -19,27 +20,33 @@
 
                 {% if provider == 'gmail' %}
                     <a href="https://mail.google.com/" target="_blank">
-                        <button class="btn waves-effect waves-ripple green">Confirm Email</button>
+                        <button class="btn waves-effect waves-ripple google-color">Confirm Email
+                            <i class="fab fa-google fa-xs"></i>
+                        </button>
                     </a>
                 {% elif provider == 'yahoo' %}
                     <a href="https://overview.mail.yahoo.com/" target="_blank">
-                        <button class="btn waves-effect waves-ripple green">Confirm Email</button>
+                        <button class="btn waves-effect waves-ripple yahoo">Confirm Email
+                            <i class="fab fa-yahoo"></i>
+                        </button>
                     </a>
                 {% elif provider == 'outlook' %}
                     <a href="https://outlook.live.com/owa/" target=" _blank">
-                        <button class="btn waves-effect waves-ripple green">Confirm Email</button>
-                    </a>
-                {% elif provider == 'inbox' %}
-                    <a href="http://www.inbox.com/" target=" _blank">
-                        <button class="btn waves-effect waves-ripple green">Confirm Email</button>
+                        <button class="btn waves-effect waves-ripple outlook">Confirm Email
+                            <i class="fas fa-envelope"></i>
+                        </button>
                     </a>
                 {% elif provider == 'icloud' %}
                     <a href="https://www.icloud.com/" target=" _blank">
-                        <button class="btn waves-effect waves-ripple green">Confirm Email</button>
+                        <button class="btn waves-effect waves-ripple icloud">Confirm Email
+                            <i class="fab fa-apple"></i>
+                        </button>
                     </a>
                 {% else %}
                     <a href="https://www.google.com/" target=" _blank">
-                        <button class="btn waves-effect waves-ripple green">Confirm Email</button>
+                        <button class="btn waves-effect waves-ripple green">Confirm Email
+                            <i class="material-icons">send</i>
+                        </button>
                     </a>
                 {% endif %}
             </div>


### PR DESCRIPTION
#### Short description of what this resolves:
Changes the confirm email page icons so that they can indicate to the user that they are abou to
open their email

#### Changes proposed in this pull request:

- change icons
-
-
#### Screenshots:
## gmail

![Screenshot from 2019-07-26 16-03-59](https://user-images.githubusercontent.com/47446639/62053610-a648d780-b220-11e9-99ad-76e9a56d004a.png)

## yahoo

![Screenshot from 2019-07-26 16-09-30](https://user-images.githubusercontent.com/47446639/62053617-aa74f500-b220-11e9-940e-452e8ba71736.png)

## outlook

![Screenshot from 2019-07-26 16-23-51](https://user-images.githubusercontent.com/47446639/62053684-c7112d00-b220-11e9-9c32-90db2b61b8d2.png)

## icloud

![Screenshot from 2019-07-26 16-34-39](https://user-images.githubusercontent.com/47446639/62053702-ced0d180-b220-11e9-9be6-9465cc5d3893.png)

**Fixes**: [#163413670](https://www.pivotaltracker.com/story/show/163413670)

